### PR TITLE
fix: do not compile CMAKE_SIZEOF_*.c in ASCII

### DIFF
--- a/patches/zos-v3.18.0.patch
+++ b/patches/zos-v3.18.0.patch
@@ -151,29 +151,34 @@ index 40668a3e6b..f04506aad2 100644
  #  define ARCHITECTURE_ID ""
  # endif
 diff --git a/Modules/CheckTypeSize.cmake b/Modules/CheckTypeSize.cmake
-index 2b07b7cc03..036f913aed 100644
+index 2b07b7cc03..b010c9c3cb 100644
 --- a/Modules/CheckTypeSize.cmake
 +++ b/Modules/CheckTypeSize.cmake
-@@ -117,6 +117,12 @@ function(__check_type_size_impl type var map builtin language)
+@@ -117,6 +117,17 @@ function(__check_type_size_impl type var map builtin language)
    endif()
    set(bin ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CheckTypeSize/${var}.bin)
    configure_file(${__check_type_size_dir}/CheckTypeSize.c.in ${src} @ONLY)
++  
++  # Add Flag for z/OS compilers for ebcdic encoding of string literals.
 +  if(CMAKE_SYSTEM_NAME MATCHES "OS390")
++    # Only need to modify CMAKE_C_FLAGS as CheckTypeSize.c.in is in C
 +    set(CMAKE_C_FLAGS_SAVE ${CMAKE_C_FLAGS})
-+    set(CMAKE_CXX_FLAGS_SAVE ${CMAKE_CXX_FLAGS})
-+    string(REGEX REPLACE "-(qASCII|qascii|fzos-le-char-mode=ascii);?" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-+    string(REGEX REPLACE "-(qASCII|qascii|fzos-le-char-mode=ascii);?" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++    if(CMAKE_C_COMPILER_ID MATCHES "Clang")
++      string(APPEND CMAKE_C_FLAGS " -fzos-le-char-mode=ebcdic")
++    elseif(CMAKE_C_COMPILER_ID MATCHES "zOS")
++      string(APPEND CMAKE_C_FLAGS " -qNoASCII")
++    endif()
 +  endif()
    try_compile(HAVE_${var} ${CMAKE_BINARY_DIR} ${src}
      COMPILE_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS}
      LINK_OPTIONS ${CMAKE_REQUIRED_LINK_OPTIONS}
-@@ -127,6 +133,10 @@ function(__check_type_size_impl type var map builtin language)
+@@ -127,6 +138,10 @@ function(__check_type_size_impl type var map builtin language)
      OUTPUT_VARIABLE output
      COPY_FILE ${bin}
      )
++  # Restore flags for z/OS compilers.
 +  if(CMAKE_SYSTEM_NAME MATCHES "OS390")
 +    set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS_SAVE})
-+    set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_SAVE})
 +  endif()
  
    if(HAVE_${var})

--- a/patches/zos-v3.18.0.patch
+++ b/patches/zos-v3.18.0.patch
@@ -150,6 +150,34 @@ index 40668a3e6b..f04506aad2 100644
  # else /* unknown architecture */
  #  define ARCHITECTURE_ID ""
  # endif
+diff --git a/Modules/CheckTypeSize.cmake b/Modules/CheckTypeSize.cmake
+index 2b07b7cc03..036f913aed 100644
+--- a/Modules/CheckTypeSize.cmake
++++ b/Modules/CheckTypeSize.cmake
+@@ -117,6 +117,12 @@ function(__check_type_size_impl type var map builtin language)
+   endif()
+   set(bin ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CheckTypeSize/${var}.bin)
+   configure_file(${__check_type_size_dir}/CheckTypeSize.c.in ${src} @ONLY)
++  if(CMAKE_SYSTEM_NAME MATCHES "OS390")
++    set(CMAKE_C_FLAGS_SAVE ${CMAKE_C_FLAGS})
++    set(CMAKE_CXX_FLAGS_SAVE ${CMAKE_CXX_FLAGS})
++    string(REGEX REPLACE "-(qASCII|qascii|fzos-le-char-mode=ascii);?" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
++    string(REGEX REPLACE "-(qASCII|qascii|fzos-le-char-mode=ascii);?" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
++  endif()
+   try_compile(HAVE_${var} ${CMAKE_BINARY_DIR} ${src}
+     COMPILE_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS}
+     LINK_OPTIONS ${CMAKE_REQUIRED_LINK_OPTIONS}
+@@ -127,6 +133,10 @@ function(__check_type_size_impl type var map builtin language)
+     OUTPUT_VARIABLE output
+     COPY_FILE ${bin}
+     )
++  if(CMAKE_SYSTEM_NAME MATCHES "OS390")
++    set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS_SAVE})
++    set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_SAVE})
++  endif()
+ 
+   if(HAVE_${var})
+     # The check compiled.  Load information from the binary.
 diff --git a/Modules/Compiler/Clang.cmake b/Modules/Compiler/Clang.cmake
 index bb516d3a20..7aa2129cfa 100644
 --- a/Modules/Compiler/Clang.cmake


### PR DESCRIPTION
The `CheckTypeSize` module works by searching for the eye-catcher "INFO:size" within the `CMAKE_SIZEOF_*` check executable:

```
# The check compiled.  Load information from the binary.
    file(STRINGS ${bin} strings LIMIT_COUNT 10 REGEX "INFO:size")
```

However the search will fail if the check executable is compiled in ASCII:
- `CFLAGS="-fzos-le-char-mode=ascii" cmake ..`, or
- `cmake .. -DCMAKE_C_FLAGS="-fzos-le-char-mode=ascii"`

Because the eye-catcher is now in ASCII within the executable, which the EBCDIC `cmake` is not able to see.

The fix is to temporary append `-qNoASCII` or `-fzos-le-char-mode=ebcdic` to `CMAKE_C_FLAGS` while compiling the `CMAKE_SIZEOF_*` check executable, and restore them once it's done.

The code has been tested with the following variations:

```
CC="/bin/xlc" CXX="/bin/xlC" cmake .. -DCMAKE_C_FLAGS="-qascii" -DCMAKE_CXX_FLAGS="-qascii"
CC="/bin/xlclang" CXX="/bin/xlclang++" cmake .. -DCMAKE_C_FLAGS="-qascii" -DCMAKE_CXX_FLAGS="-qascii"
CC="/bin/xlc" CXX="/bin/xlC" cmake .. -DCMAKE_C_FLAGS="-Wc,ASCII" -DCMAKE_CXX_FLAGS="-Wc,ASCII"
CC="/bin/xlclang" CXX="/bin/xlclang++" cmake .. -DCMAKE_C_FLAGS="-Wc,ASCII" -DCMAKE_CXX_FLAGS="-Wc,ASCII"

CC="/bin/xlc" CXX="/bin/xlC" CFLAGS="-qascii" CXXFLAGS="-qascii" cmake .. 
CC="/bin/xlclang" CXX="/bin/xlclang++" CFLAGS="-qascii" CXXFLAGS="-qascii" cmake .. 
CC="/bin/xlc" CXX="/bin/xlC" CFLAGS="-Wc,ASCII" CXXFLAGS="-Wc,ASCII" cmake .. 
CC="/bin/xlclang" CXX="/bin/xlclang++" CFLAGS="-Wc,ASCII" CXXFLAGS="-Wc,ASCII" cmake .. 

CC="ibm-clang64 --config /etc/clang.cfg" CXX="ibm-clang++64 --config /etc/clang.cfg" cmake .. -DCMAKE_C_FLAGS="-fzos-le-char-mode=ascii" -DCMAKE_CXX_FLAGS="-fzos-le-char-mode=ascii"

CC="ibm-clang64 --config /etc/clang.cfg" CXX="ibm-clang++64 --config /etc/clang.cfg" CFLAGS="-fzos-le-char-mode=ascii" CXXFLAGS="-fzos-le-char-mode=ascii" cmake .. 
```

Thanks to @fanbo-meng for the idea.